### PR TITLE
Make TokenType.ZanoAsset serializable

### DIFF
--- a/marketkit/src/main/java/io/horizontalsystems/marketkit/models/TokenType.kt
+++ b/marketkit/src/main/java/io/horizontalsystems/marketkit/models/TokenType.kt
@@ -40,7 +40,7 @@ sealed class TokenType : Parcelable {
     @Parcelize @Serializable
     data class Asset(val code: String, val issuer: String) : TokenType()
 
-    @Parcelize
+    @Parcelize @Serializable
     data class ZanoAsset(val reference: String): TokenType()
 
     @Parcelize @Serializable

--- a/marketkit/src/test/java/io/horizontalsystems/marketkit/TokenTypeSerializationTest.kt
+++ b/marketkit/src/test/java/io/horizontalsystems/marketkit/TokenTypeSerializationTest.kt
@@ -1,0 +1,34 @@
+package io.horizontalsystems.marketkit
+
+import io.horizontalsystems.marketkit.models.TokenType
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TokenTypeSerializationTest {
+
+    private val tokenTypes = listOf(
+        TokenType.Native,
+        TokenType.Derived(TokenType.Derivation.Bip84),
+        TokenType.AddressTyped(TokenType.AddressType.Type145),
+        TokenType.Eip20("0x0000000000000000000000000000000000000001"),
+        TokenType.Spl("So11111111111111111111111111111111111111112"),
+        TokenType.Jetton("EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+        TokenType.Asset("USDC", "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"),
+        TokenType.ZanoAsset("aaaabbbbccccdddd"),
+        TokenType.ThorchainAsset("rune"),
+        TokenType.Unsupported("unsupported", "reference"),
+    )
+
+    // Array polymorphism keeps the class discriminator out of the object body, so that
+    // subclasses with a "type" property (AddressTyped) do not collide with it.
+    private val json = Json { useArrayPolymorphism = true }
+
+    @Test
+    fun everySubclassRoundTripsPolymorphically() {
+        tokenTypes.forEach { tokenType ->
+            val encoded = json.encodeToString(TokenType.serializer(), tokenType)
+            assertEquals(tokenType, json.decodeFromString(TokenType.serializer(), encoded))
+        }
+    }
+}


### PR DESCRIPTION
`TokenType.ZanoAsset` was the only subclass of the sealed `TokenType` declared without `@Serializable`, so it was never registered in the polymorphic scope. Any attempt to serialize a `Token` holding it threw:

```
kotlinx.serialization.SerializationException: Serializer for subclass 'ZanoAsset' is not found
in the polymorphic scope of 'TokenType'.
```

In unstoppable-wallet-android this crashes the app on `onSaveInstanceState`: the Nav3 back stack serializes `TokenBalancePage` -> `Wallet` -> `Token` -> `TokenType`, so opening a Zano asset (e.g. FUSD) balance page and then backgrounding the activity — launching the QR scanner, rotating, anything — takes the process down.

## Changes

- Add `@Serializable` to `TokenType.ZanoAsset`.
- Add `TokenTypeSerializationTest`, which round-trips every `TokenType` subclass polymorphically so a future subclass missing the annotation fails the build rather than crashing on device.

The test uses `Json { useArrayPolymorphism = true }`: with the default class discriminator, `AddressTyped`'s own `type` property collides with the `"type"` discriminator key. That is a JSON-format constraint only — `androidx.savedstate` nests polymorphic values instead of flattening them, so `AddressTyped` is unaffected at runtime.

## Verification

`:marketkit:testDebugUnitTest` passes with the fix and fails when the annotation is removed. Built against unstoppable-wallet-android via mavenLocal; `TokenType$ZanoAsset$$serializer` is now present in the published AAR.